### PR TITLE
Use license_files instead of deprecated license_file in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ author_email = raphael.barrois+aionotify@polytechnique.org
 url = https://github.com/rbarrois/aionotify
 keywords = asyncio, inotify
 license = BSD
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers


### PR DESCRIPTION
This fixes the deprecation warning of recent setuptools versions:
```
/usr/lib/python3/dist-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
```